### PR TITLE
Configurable callbacks for model object creation

### DIFF
--- a/lib/doublemap_api/client/routes.rb
+++ b/lib/doublemap_api/client/routes.rb
@@ -4,7 +4,7 @@ module DoubleMap
 
     # Return a list of all routes on the system.
     def list
-      get_request('/map/v2/routes').map{ |route| Route.new(route) }
+      get_request('/map/v2/routes').map{ |route| Route.new(route) }.map(&route_map)
     end
     memoize :list
     alias_method :all, :list
@@ -15,5 +15,11 @@ module DoubleMap
     end
     memoize :get
     alias_method :find, :get
+
+    private
+
+    def route_map
+      DoubleMap.configuration.route_map
+    end
   end
 end

--- a/lib/doublemap_api/client/routes.rb
+++ b/lib/doublemap_api/client/routes.rb
@@ -4,7 +4,7 @@ module DoubleMap
 
     # Return a list of all routes on the system.
     def list
-      get_request('/map/v2/routes').map{ |route| Route.new(route) }.map(&route_map)
+      get_request('/map/v2/routes').map{ |route| Route.new(route) }.each(&on_route)
     end
     memoize :list
     alias_method :all, :list
@@ -18,8 +18,8 @@ module DoubleMap
 
     private
 
-    def route_map
-      DoubleMap.configuration.route_map
+    def on_route
+      DoubleMap.configuration.on_route
     end
   end
 end

--- a/lib/doublemap_api/client/stops.rb
+++ b/lib/doublemap_api/client/stops.rb
@@ -4,7 +4,7 @@ module DoubleMap
 
     # Return a list of all stops on the system.
     def list
-      get_request('/map/v2/stops').map{ |stop| Stop.new(stop) }.map(&stop_map)
+      get_request('/map/v2/stops').map{ |stop| Stop.new(stop) }.each(&on_stop)
     end
     memoize :list
     alias_method :all, :list
@@ -18,8 +18,8 @@ module DoubleMap
 
     private
 
-    def stop_map
-      DoubleMap.configuration.stop_map
+    def on_stop
+      DoubleMap.configuration.on_stop
     end
   end
 end

--- a/lib/doublemap_api/client/stops.rb
+++ b/lib/doublemap_api/client/stops.rb
@@ -4,7 +4,7 @@ module DoubleMap
 
     # Return a list of all stops on the system.
     def list
-      get_request('/map/v2/stops').map{ |stop| Stop.new(stop) }
+      get_request('/map/v2/stops').map{ |stop| Stop.new(stop) }.map(&stop_map)
     end
     memoize :list
     alias_method :all, :list
@@ -15,5 +15,11 @@ module DoubleMap
     end
     memoize :get
     alias_method :find, :get
+
+    private
+
+    def stop_map
+      DoubleMap.configuration.stop_map
+    end
   end
 end

--- a/lib/doublemap_api/client/vehicles.rb
+++ b/lib/doublemap_api/client/vehicles.rb
@@ -4,7 +4,7 @@ module DoubleMap
 
     # Return a list of all vehicles currently traveling on routes.
     def list
-      get_request('/map/v2/buses').map{ |vehicle| Vehicle.new(vehicle) }
+      get_request('/map/v2/buses').map{ |vehicle| Vehicle.new(vehicle) }.map(&vehicle_map)
     end
     memoize :list
     alias_method :all, :list
@@ -15,5 +15,11 @@ module DoubleMap
     end
     memoize :get
     alias_method :find, :get
+
+    private
+
+    def vehicle_map
+      DoubleMap.configuration.vehicle_map
+    end
   end
 end

--- a/lib/doublemap_api/client/vehicles.rb
+++ b/lib/doublemap_api/client/vehicles.rb
@@ -4,7 +4,7 @@ module DoubleMap
 
     # Return a list of all vehicles currently traveling on routes.
     def list
-      get_request('/map/v2/buses').map{ |vehicle| Vehicle.new(vehicle) }.map(&vehicle_map)
+      get_request('/map/v2/buses').map{ |vehicle| Vehicle.new(vehicle) }.each(&on_vehicle)
     end
     memoize :list
     alias_method :all, :list
@@ -18,8 +18,8 @@ module DoubleMap
 
     private
 
-    def vehicle_map
-      DoubleMap.configuration.vehicle_map
+    def on_vehicle
+      DoubleMap.configuration.on_vehicle
     end
   end
 end

--- a/lib/doublemap_api/configuration.rb
+++ b/lib/doublemap_api/configuration.rb
@@ -8,12 +8,18 @@ module DoubleMap
     attr_accessor :adapter
     # The output stream to which debug information should be written
     attr_accessor :debug_output
+    # Procs to transform route, stop, or vehicle objects before being returned
+    # to a caller
+    attr_accessor :route_map, :stop_map, :vehicle_map
 
     # The defaults to use for any configuration options that are not provided
     DEFAULT_CONFIGURATION = {
       version: '3.2', # Taken from a comment on "http://bus.gocitybus.com/RouteMap/Index"
       adapter: :httparty,
-      debug_output: false
+      debug_output: false,
+      route_map: ->(r){ r },
+      stop_map: ->(s){ s },
+      vehicle_map: ->(v){ v },
     }
 
     # The options required when configuring a DoubleMap instance

--- a/lib/doublemap_api/configuration.rb
+++ b/lib/doublemap_api/configuration.rb
@@ -8,18 +8,18 @@ module DoubleMap
     attr_accessor :adapter
     # The output stream to which debug information should be written
     attr_accessor :debug_output
-    # Procs to transform route, stop, or vehicle objects before being returned
-    # to a caller
-    attr_accessor :route_map, :stop_map, :vehicle_map
+    # Optional procs called when a corresponding model object is created,
+    # before it is returned to a caller.
+    attr_accessor :on_route, :on_stop, :on_vehicle
 
     # The defaults to use for any configuration options that are not provided
     DEFAULT_CONFIGURATION = {
       version: '3.2', # Taken from a comment on "http://bus.gocitybus.com/RouteMap/Index"
       adapter: :httparty,
       debug_output: false,
-      route_map: ->(r){ r },
-      stop_map: ->(s){ s },
-      vehicle_map: ->(v){ v },
+      on_route: ->(_){},
+      on_stop: ->(_){},
+      on_vehicle: ->(_){},
     }
 
     # The options required when configuring a DoubleMap instance

--- a/lib/doublemap_api/configuration.rb
+++ b/lib/doublemap_api/configuration.rb
@@ -17,9 +17,9 @@ module DoubleMap
       version: '3.2', # Taken from a comment on "http://bus.gocitybus.com/RouteMap/Index"
       adapter: :httparty,
       debug_output: false,
-      on_route: ->(_){},
-      on_stop: ->(_){},
-      on_vehicle: ->(_){},
+      on_route: ->(route){},
+      on_stop: ->(stop){},
+      on_vehicle: ->(vehicle){},
     }
 
     # The options required when configuring a DoubleMap instance

--- a/test/configuration.rb
+++ b/test/configuration.rb
@@ -15,6 +15,3 @@ puts double_map.routes.get(v.route).name
 r.stops.each do |stop_id|
   puts double_map.stops.get(stop_id).name
 end
-
-require 'pry'; binding.pry
-puts 'exit'

--- a/test/configuration.rb
+++ b/test/configuration.rb
@@ -15,3 +15,6 @@ puts double_map.routes.get(v.route).name
 r.stops.each do |stop_id|
   puts double_map.stops.get(stop_id).name
 end
+
+require 'pry'; binding.pry
+puts 'exit'


### PR DESCRIPTION
I want to enable ad-hoc overriding of data returned from Doublemap, to enable some agency-specific modifications where necessary. Optional `on_route`, `on_stop`, and `on_vehicle` procs can be declared in the configuration. When a model object is created, its respective proc is called, which can manipulate the model objects in any way.

For example, Citybus right now has some bad data in their doublemap feed—they don't publish the stop code (TEMPJC) for the "Jefferson Center" stop. API consumers can use a `stop_map` to manually find the Jefferson Center stop and fix it by manually setting the stop code.